### PR TITLE
Fix bad performance in _asn1_delete_structrue

### DIFF
--- a/lib/structure.c
+++ b/lib/structure.c
@@ -347,19 +347,25 @@ _asn1_delete_structure (list_type *e_list, asn1_node * structure, unsigned int f
 		{
 		  p3 = _asn1_find_up (p);
 		  if (p3)
+		  {
 		    _asn1_set_down (p3, p2);
+		    p = NULL;
+		  }
 		  else
 		    {
 		      if (p->right)
 			p->right->left = NULL;
+		      p = p2;
 		    }
 		}
 	      else
+	        {
 		_asn1_set_right (p3, p2);
+		 p = NULL;
+	        }
 	      if (e_list)
 		_asn1_delete_node_from_list (e_list, p);
 	      _asn1_remove_node (p, flags);
-	      p = NULL;
 	    }
 	}
     }


### PR DESCRIPTION
I found a memory leak in fuzz test and track to_asn1_delete_structrue( ).I thought if the structure node have a father node, the brother node of structure can be connected to the father node.But if not, the the right node is not used any more.They should be free,in fact not.